### PR TITLE
Symbol ' possible in refname, so try define string with '''

### DIFF
--- a/git-big-picture
+++ b/git-big-picture
@@ -551,7 +551,7 @@ class Git(object):
             mapping of non-commit sha1s to sets of strings
         """
 
-        output = self("git for-each-ref --format=\"['%(objectname)', '%(*objectname)',  '%(objecttype)', '%(refname)']\"")
+        output = self("git for-each-ref --format=\"['%(objectname)', '%(*objectname)',  '%(objecttype)', '''%(refname)''']\"")
         lbranch_prefix = 'refs/heads/'
         rbranch_prefix = 'refs/remotes/'
         tag_prefix = 'refs/tags/'


### PR DESCRIPTION
Found couple refnames with symbol ' in name.
Proposed change solves problem in my repository, though I do not sure if it correct because I am not Python developer.