### PR TITLE
Be robust with regard to branch names that contain tick characters ("'") (finishes up on #27)

### DIFF
--- a/git-big-picture
+++ b/git-big-picture
@@ -885,6 +885,7 @@ class CommitGraph:
         for sha_one, labels, color in label_gen():
             label = '\\n'.join(labels + ((with_commit_messages or sha_ones_on_labels) and [
                 format_label(sha_one), ] or list()))
+            label = label.replace('"', '\\"')
             dot_file_lines.append(f'\t"{sha_one}"[label="{label}", color="{color}", style=filled];')
         for sha_one in self.dotdot:
             dot_file_lines.append(

--- a/git-big-picture
+++ b/git-big-picture
@@ -21,6 +21,7 @@
 # along with git-big-picture.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import ast
 import copy
 import os
 import re
@@ -581,8 +582,8 @@ class Git:
             mapping of non-commit sha1s to sets of strings
         """
 
-        ref_format = "['%(objectname)', '%(*objectname)',  '%(objecttype)', '%(refname)']"
-        output = self(['git', 'for-each-ref', f'--format={ref_format}'])
+        ref_format = '[%(objectname), %(*objectname), %(objecttype), %(refname)]'
+        output = self(['git', 'for-each-ref', f'--format={ref_format}', '--python'])
         lbranch_prefix = 'refs/heads/'
         rbranch_prefix = 'refs/remotes/'
         tag_prefix = 'refs/tags/'
@@ -593,7 +594,7 @@ class Git:
             dic.setdefault(sha1, set()).add(name)
 
         for ref_info in output:
-            sha1, tag_sha1, ref_type, name = eval(ref_info)
+            sha1, tag_sha1, ref_type, name = ast.literal_eval(ref_info)
             if ref_type not in ['commit', 'tag']:
                 continue
             elif name.startswith(lbranch_prefix):

--- a/test.scf
+++ b/test.scf
@@ -126,8 +126,9 @@ try profiling
     $ rm stats file.svg
     $ ls
 
-be robust with regard to branch names that contain tick characters ("'")
+be robust with regard to branch names that contain special characters
     $ git branch "single'tick"
     $ git branch "one'two'three"
-    $ git-big-picture -g > /dev/null
+    $ git branch 'double"quote'
+    $ git-big-picture -w0 -v true
     [0]

--- a/test.scf
+++ b/test.scf
@@ -125,3 +125,9 @@ try profiling
     stats
     $ rm stats file.svg
     $ ls
+
+crash on branch names that contain single ticks ("'")
+    $ git branch "single'tick"
+    $ set -o pipefail; git-big-picture -g |& tail -n1
+    SyntaxError: invalid syntax
+    [1]

--- a/test.scf
+++ b/test.scf
@@ -126,8 +126,8 @@ try profiling
     $ rm stats file.svg
     $ ls
 
-crash on branch names that contain single ticks ("'")
+be robust with regard to branch names that contain tick characters ("'")
     $ git branch "single'tick"
-    $ set -o pipefail; git-big-picture -g |& tail -n1
-    SyntaxError: invalid syntax
-    [1]
+    $ git branch "one'two'three"
+    $ git-big-picture -g > /dev/null
+    [0]


### PR DESCRIPTION
Finishes up on pull request #27 by rebasing onto latest `master` and by adding a simple test.

~Sits on top of #50 to avoid merge conflicts for the moment.~