### PR TITLE
test.scf: Drop accidental test suite duplication

### DIFF
--- a/test.scf
+++ b/test.scf
@@ -29,8 +29,6 @@ create a fake repo (i.e. global setup for all following tests)
     $ git commit -q --allow-empty -m "foo"
 
 run without options
-    $ git init -q
-    $ git commit -q --allow-empty -m "foo"
     $ git-big-picture .
     2: fatal: Must provide an output option. Try '-h' for more information
     [8]


### PR DESCRIPTION
The same two lines are run in the "global setup" test above, already. Introduced in #50.