### PR TITLE
tests: Cover option precedence on the command line

### DIFF
--- a/test.scf
+++ b/test.scf
@@ -38,11 +38,11 @@ cover including commit messsages (smoke test)
     $ git-big-picture -c -g >/dev/null
 
 test option precedence for -C followed by -c (include commit messages)
-    $ git-big-picture -g -C -c | grep 'foo'
+    $ git-big-picture -g -C -c | grep -q 'foo'
     [0]
 
 test option precedence for -c followed by -C (don't include commit messages)
-    $ git-big-picture -g -c -C | grep 'foo'
+    $ git-big-picture -g -c -C | grep -q 'foo'
     [1]
 
 mix --graphviz and --processed and others

--- a/test.scf
+++ b/test.scf
@@ -36,7 +36,14 @@ run without options
 
 cover including commit messsages (smoke test)
     $ git-big-picture -c -g >/dev/null
+
+test option precedence for -C followed by -c (include commit messages)
+    $ git-big-picture -g -C -c | grep 'foo'
     [0]
+
+test option precedence for -c followed by -C (don't include commit messages)
+    $ git-big-picture -g -c -C | grep 'foo'
+    [1]
 
 mix --graphviz and --processed and others
     $ git-big-picture -p -g


### PR DESCRIPTION
Options can override each other and the last one has precedence. Here, we
test both including and excluding commit messages and test by using grep
on the graphviz output, looking for the single  commit message.