### PR TITLE
Pin and auto-update test requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
       - "enhancement"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    commit-message:
+      include: "scope"
+      prefix: "requirements"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "daily"

--- a/run-tests-with-coverage.sh
+++ b/run-tests-with-coverage.sh
@@ -49,10 +49,15 @@ cd "${temp_dir}"
 #          while still not hardcoding a specific temp directory.
 
 # Prepare a virtualenv ready to run tests with subprocess coverage
+# Also check for (and enforce) conflict-free and all-pinned dependencies
 python3 -m venv ${venv}
 source ${venv}/bin/activate
 pip install --quiet --disable-pip-version-check -r "${source_dir}"/test_requirements.txt
 pip install --quiet --disable-pip-version-check -e "${source_dir}"
+pip check > /dev/null
+diff -U0 \
+    <(sed -e '/#.*/d' -e '/^$/d' "${source_dir}"/test_requirements.txt | sort -f) \
+    <(pip freeze | fgrep -v git_big_picture | sort -f)
 sed "s,\./,${source_dir}/,g" "${source_dir}"/.coveragerc > .coveragerc
 cat <<SITECUSTOMIZE_PY_EOF > "$(ls -1d ${venv}/lib/python*)"/site-packages/sitecustomize.py
 try:

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,17 @@ from git_big_picture import __version__ as VERSION
 with open('README.rst') as f:
     long_description = f.read()
 
+_tests_require = [
+    # Keep in sync with test_requirements.txt
+    'coverage',
+    'pytest',
+    'scruf',
+]
+
+_extras_require = {
+    'tests': _tests_require,
+}
+
 setup(name = 'git-big-picture',
     version = VERSION,
     author = 'Sebastian Pipping, Julius Plenz, and Valentin Haenel',
@@ -35,6 +46,8 @@ setup(name = 'git-big-picture',
     license = 'GPL v3 or later',
     python_requires='>=3.6',
     packages=find_packages(),
+    extras_require=_extras_require,
+    tests_require=_tests_require,
     entry_points={
         'console_scripts': [
             'git-big-picture = git_big_picture._main:main',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 # Direct dependencies
+# Keep in sync with setup.py
 coverage==5.3.1
 pytest==6.2.1
 scruf==0.4.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,16 @@
-coverage
-scruf
-pytest
+# Direct dependencies
+coverage==5.3.1
+pytest==6.2.1
+scruf==0.4.1
+
+# Indirect dependencies
+attrs==20.3.0
+importlib-metadata==3.3.0
+iniconfig==1.1.1
+packaging==20.8
+pluggy==0.13.1
+py==1.10.0
+pyparsing==2.4.7
+toml==0.10.2
+typing-extensions==3.7.4.3
+zipp==3.4.0


### PR DESCRIPTION
One benefit of this approach is that even when we'll have a month or two of no pull requests by a human in the future, we'll notice in time that updates to our third party dependencies have broken our test suite in the meantime, and which ones in detail.