### PR TITLE
Drop support for end-of-life Python 3.6 + start supporting Python 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        python-version: [3.7, 3.9]  # no urgent need for: 3.8
+        python-version: [3.7, '3.10']  # no urgent need for: 3.8, 3.9
         runs-on: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        python-version: [3.6, 3.9]  # no urgent need for: 3.7, 3.8
+        python-version: [3.7, 3.9]  # no urgent need for: 3.8
         runs-on: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: ['--py36-plus']
+        args: ['--py37-plus']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ We also have a real world examples from:
 Dependencies
 ------------
 
-* Python >=3.6
+* Python >=3.7
 * Git (1.7.1 works)
 * Graphviz utility
 * pytest and Cram (only for running tests)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
     ],
     data_files=[('share/man/man1', ['git-big-picture.1'])],

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     long_description=long_description,
     url='https://github.com/git-big-picture/git-big-picture',
     license='GPL v3 or later',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     packages=find_packages(),
     extras_require=_extras_require,
     tests_require=_tests_require,
@@ -56,7 +56,6 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
@esc this seems needed for #161 due to line https://github.com/python/importlib_metadata/blob/4abad44e30578066a24483ff118b8f29f7832a86/setup.cfg#L18 in importlib_metadata upstream, but also seems like a good idea, in general. Do you have any concerns about this step?