### PR TITLE
`README.rst`: Make screenshot dimensions match reality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,14 +80,14 @@ Courtesy of Graphviz, ``git-big-picture`` can output nice images.
 Here is the original repository from the example above:
 
 .. image:: https://raw.github.com/git-big-picture/git-big-picture/master/screenshots/before.png
-    :height: 280px
-    :width:  456px
+    :width:   492px
+    :height: 1043px
 
 And here is the reduced version:
 
 .. image:: https://raw.github.com/git-big-picture/git-big-picture/master/screenshots/after.png
-    :height: 280px
-    :width:  456px
+    :width:  280px
+    :height: 456px
 
 We also have a real world examples from:
 


### PR DESCRIPTION
```console
# file screenshots/before.png screenshots/after.png
screenshots/before.png: PNG image data, 492 x 1043, 8-bit/color RGB, non-interlaced
screenshots/after.png:  PNG image data, 280 x 456, 8-bit/color RGB, non-interlaced
```