### PR TITLE
`setup.py`: Remove `tests_require=` for Setuptools >=72.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     python_requires=">=3.9",
     packages=find_packages(),
     extras_require=_extras_require,
-    tests_require=_tests_require,
     entry_points={
         "console_scripts": [
             "git-big-picture = git_big_picture._main:main",


### PR DESCRIPTION
Related:
https://github.com/pypa/setuptools/pull/4458/commits/6404823b4a16f340b7786793cd1256fe451f47eb