### PR TITLE
Add flags `--{drop,keep}-{branches,tags}` to filter branches and tags using regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ filter options:
                         include commit messages on labels
   -C, --no-commit-messages
                         do not include commit messages on labels
+  --keep-tags REGEX     show tags matching regexp pattern
+  --keep-branches REGEX
+                        show branches matching regexp pattern
+  --drop-tags REGEX     drop tags matching regexp pattern
+  --drop-branches REGEX
+                        drop branches matching regexp pattern
 
 git-big-picture is software libre, licensed under the GPL v3 or later license.
 Please report bugs at https://github.com/git-big-picture/git-big-picture/issues — thank you!
@@ -364,6 +370,21 @@ Show all commits:
 $ git-big-picture -a
 ```
 
+### Using Filter Pattern Options
+
+By default, if `--tags` or `--branches` are active, then all nodes
+with tags or branches are shown.
+
+The four options `--keep-branches`, `--keep-tags`, `--drop-branches`,
+and `--drop-tags` allow suppression of some of these labels.  If a
+flag `--keep-tags re` is provided, then only those tags matching the
+regular expression `re` are shown.  If a flag `--drop-tags re_drop` is
+provided, then those tags matching `re_drop` are *not* shown.  The
+flags `--keep-branches re` and `--drop-branches re` work the same way
+for branch labels.
+
+If `--no-tags` or `--no-branches` is selected, then these flags have
+no effect.
 
 ## Configuration
 
@@ -473,6 +494,12 @@ $ gprof2dot -f pstats profile-stats | dot -Tsvg -o profile_stats.svg
 
 
 ## Changelog
+
+- Unreleased changes
+  - **New Features and Improvements**
+    - Add flags to show or suppress tags or labels matching regular
+      expressions.
+      ([#671](https://github.com/git-big-picture/git-big-picture/pull/671))
 
 - `v1.3.0` — 2024-03-08
   - **New Features and Improvements**

--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ Usage
     output options:
       Options to control output and format
 
-      -f, --format FMT      set output format [svg, png, ps, pdf, ...]
+      -f FMT, --format FMT  set output format [svg, png, ps, pdf, ...]
       --history-direction {downwards,leftwards,rightwards,upwards}
                             enforce a specific direction of history on Graphviz
                             (default: rightwards)
@@ -197,11 +197,13 @@ Usage
       -G, --no-graphviz     disable dot/graphviz output
       -p, --processed       output the dot processed, binary data
       -P, --no-processed    disable binary output
-      -v, --viewer CMD      write image to tempfile and start specified viewer
+      -v CMD, --viewer CMD  write image to tempfile and start specified viewer
       -V, --no-viewer       disable starting viewer
-      -o, --outfile FILE    write image to specified file
+      -o FILE, --outfile FILE
+                            write image to specified file
       -O, --no-outfile      disable writing image to file
-      -w, --wait SECONDS    wait for SECONDS seconds before deleting the temporary
+      -w SECONDS, --wait SECONDS
+                            wait for SECONDS seconds before deleting the temporary
                             file that is opened using the viewer command (default:
                             2.0 seconds); this helps e.g. with viewer commands that
                             tell other running processes to open that file on their
@@ -230,6 +232,12 @@ Usage
                             include commit messages on labels
       -C, --no-commit-messages
                             do not include commit messages on labels
+      --keep-tags REGEX     show tags matching regexp pattern
+      --keep-branches REGEX
+                            show branches matching regexp pattern
+      --drop-tags REGEX     drop tags matching regexp pattern
+      --drop-branches REGEX
+                            drop branches matching regexp pattern
 
     git-big-picture is software libre, licensed under the GPL v3 or later license.
     Please report bugs at https://github.com/git-big-picture/git-big-picture/issues — thank you!
@@ -463,6 +471,13 @@ uses Graphviz too:
 
 Changelog
 ---------
+
+* Unreleased changes
+
+  * **New Features and Improvements**
+
+    * Add flags to show or suppress tags or labels matching regular expressions.
+      ([#671](https://github.com/git-big-picture/git-big-picture/pull/671))
 
 * ``v1.3.0`` — 2024-03-08
 

--- a/git-big-picture.1
+++ b/git-big-picture.1
@@ -118,6 +118,18 @@ include commit messages on labels
 .TP
 \fB\-C\fR, \fB\-\-no\-commit\-messages\fR
 do not include commit messages on labels
+.TP
+\fB\-\-keep\-tags\fR REGEX
+show tags matching regexp pattern
+.TP
+\fB\-\-keep\-branches\fR REGEX
+show branches matching regexp pattern
+.TP
+\fB\-\-drop\-tags\fR REGEX
+drop tags matching regexp pattern
+.TP
+\fB\-\-drop\-branches\fR REGEX
+drop branches matching regexp pattern
 .PP
 .SH EPILOG
 

--- a/git_big_picture/_main.py
+++ b/git_big_picture/_main.py
@@ -69,12 +69,20 @@ TAGS = "tags"
 ROOTS = "roots"
 MERGES = "merges"
 BIFURCATIONS = "bifurcations"
+FILTER_KEEP_BRANCHES = "keep_branches"
+FILTER_KEEP_TAGS = "keep_tags"
+FILTER_DROP_BRANCHES = "drop_branches"
+FILTER_DROP_TAGS = "drop_tags"
 FILTER_SETTINGS = [
     BRANCHES,
     TAGS,
     ROOTS,
     MERGES,
     BIFURCATIONS,
+    FILTER_KEEP_BRANCHES,
+    FILTER_KEEP_TAGS,
+    FILTER_DROP_BRANCHES,
+    FILTER_DROP_TAGS,
 ]
 FILTER_DEFAULTS = {
     BRANCHES: True,
@@ -82,6 +90,10 @@ FILTER_DEFAULTS = {
     ROOTS: True,
     MERGES: False,
     BIFURCATIONS: False,
+    FILTER_KEEP_BRANCHES: None,
+    FILTER_KEEP_TAGS: None,
+    FILTER_DROP_BRANCHES: None,
+    FILTER_DROP_TAGS: None,
 }
 
 # annotation settings
@@ -131,6 +143,13 @@ _EPILOG = textwrap.dedent("""
 """)
 
 _RIGHT_COLUMN_WRAP_WIDTH = 57
+
+
+def regex_type(s):
+    try:
+        return re.compile(s)
+    except re.error as e:
+        raise argparse.ArgumentTypeError(f"Invalid regex: {s} - {e}")
 
 
 def create_parser():
@@ -372,6 +391,34 @@ def create_parser():
         action="store_false",
         dest=MESSAGES,
         help="do not include commit messages on labels",
+    )
+    filter_group.add_argument(
+        "--keep-tags",
+        type=regex_type,
+        dest=FILTER_KEEP_TAGS,
+        metavar="REGEX",
+        help="show tags matching regexp pattern",
+    )
+    filter_group.add_argument(
+        "--keep-branches",
+        type=regex_type,
+        dest=FILTER_KEEP_BRANCHES,
+        metavar="REGEX",
+        help="show branches matching regexp pattern",
+    )
+    filter_group.add_argument(
+        "--drop-tags",
+        type=regex_type,
+        dest=FILTER_DROP_TAGS,
+        metavar="REGEX",
+        help="drop tags matching regexp pattern",
+    )
+    filter_group.add_argument(
+        "--drop-branches",
+        type=regex_type,
+        dest=FILTER_DROP_BRANCHES,
+        metavar="REGEX",
+        help="drop branches matching regexp pattern",
     )
 
     # miscellaneous options
@@ -948,6 +995,10 @@ class CommitGraph:
         merges=FILTER_DEFAULTS[MERGES],
         bifurcations=FILTER_DEFAULTS[BIFURCATIONS],
         additional=None,
+        keep_branches=FILTER_DEFAULTS[FILTER_KEEP_BRANCHES],
+        keep_tags=FILTER_DEFAULTS[FILTER_KEEP_TAGS],
+        drop_branches=FILTER_DEFAULTS[FILTER_DROP_BRANCHES],
+        drop_tags=FILTER_DEFAULTS[FILTER_DROP_TAGS],
     ):
         """Filter the commit graph.
 
@@ -973,6 +1024,14 @@ class CommitGraph:
             include bifurcation commits
         additional : list of SHA1 sums
             any additional commits to include
+        keep_branches : regexp
+            pattern to match branches to include (if branches=True), default=All
+        keep_tags : regexp
+            pattern to match tags to include (if tags=True), default=All
+        drop_branches : regexp
+            pattern to match branches to drop (of those included above), default=None
+        drop_tags : regexp
+            pattern to match tags to drop (of those included above), default=None
 
         Returns
         -------
@@ -981,10 +1040,81 @@ class CommitGraph:
 
         """
         interesting = []
+
         if branches:
-            interesting.extend(self.branches.keys())
+            if keep_branches:
+                if drop_branches:
+                    interesting.extend(
+                        {
+                            sha1
+                            for sha1, branch_names in self.branches.items()
+                            if any(
+                                (
+                                    re.search(keep_branches, branch_name)
+                                    and not re.search(drop_branches, branch_name)
+                                )
+                                for branch_name in branch_names
+                            )
+                        }
+                    )
+                else:
+                    interesting.extend(
+                        {
+                            sha1
+                            for sha1, branch_names in self.branches.items()
+                            if any(
+                                re.search(keep_branches, branch_name)
+                                for branch_name in branch_names
+                            )
+                        }
+                    )
+            elif drop_branches:
+                interesting.extend(
+                    {
+                        sha1
+                        for sha1, branch_names in self.branches.items()
+                        if any(
+                            (not re.search(drop_branches, branch_name))
+                            for branch_name in branch_names
+                        )
+                    }
+                )
+            else:
+                interesting.extend(self.branches.keys())
         if tags:
-            interesting.extend(self.tags.keys())
+            if keep_tags:
+                if drop_tags:
+                    interesting.extend(
+                        {
+                            sha1
+                            for sha1, tag_names in self.tags.items()
+                            if any(
+                                (
+                                    re.search(keep_tags, tag_name)
+                                    and (not re.search(drop_tags, tag_name))
+                                )
+                                for tag_name in tag_names
+                            )
+                        }
+                    )
+                else:
+                    interesting.extend(
+                        {
+                            sha1
+                            for sha1, tag_names in self.tags.items()
+                            if any(re.search(keep_tags, tag_name) for tag_name in tag_names)
+                        }
+                    )
+            elif drop_tags:
+                interesting.extend(
+                    {
+                        sha1
+                        for sha1, tag_names in self.tags.items()
+                        if any((not re.search(drop_tags, tag_name)) for tag_name in tag_names)
+                    }
+                )
+            else:
+                interesting.extend(self.tags.keys())
         if roots:
             interesting.extend(self.roots)
         if merges:

--- a/test.py
+++ b/test.py
@@ -20,6 +20,7 @@
 # along with git-big-picture.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 import shlex
 import shutil as sh
 import sys
@@ -478,3 +479,244 @@ class TestGitTools(_GitRepoTestMixin, ut.TestCase):
             p: {b},
         }
         self.assertEqual(expected_reduced_parents, filterd_graph.parents)
+
+    def test_keep_drop(self):
+        r"""Test keep and drop.
+
+        Before:
+
+          x---A---B---C---D---E---F master
+              |   |    \         /
+             0.0 0.1    N---O---P topic1
+
+        After:
+
+            A 0.0---B 0.1---F master
+                      \     /
+                       P topic1
+
+        """
+        x = empty_commit("x")
+        a = empty_commit("A")
+        tag(a, "0.0")
+        b = empty_commit("B")
+        tag(b, "0.1")
+        c = empty_commit("C")
+        empty_commit("D")
+        empty_commit("E")
+        dispatch("git checkout -b topic1 %s" % c)
+        empty_commit("N")
+        empty_commit("O")
+        p = empty_commit("P")
+        dispatch("git checkout master")
+        dispatch("git merge topic1")
+        f = get_head_sha()
+        graph = self.graph
+        filtered_graph = graph.filter(roots=False)
+        expected_reduced_parents = {
+            a: set(),
+            b: {a},
+            f: {p, b},
+            p: {b},
+        }
+        dispatch(f"git log --oneline {f}..{p}")
+        self.assertEqual(expected_reduced_parents, filtered_graph.parents)
+
+        # include nodes with tags matching "1" and branches matching "[a-z]"
+        # After:
+        #
+        #          B 0.1---F master
+        #             \     /
+        #              P topic1
+        filtered_graph2 = graph.filter(
+            roots=False, keep_tags=re.compile("1"), keep_branches=re.compile("[a-z]")
+        )
+        expected_reduced_parents2 = {
+            b: set(),
+            f: {p, b},
+            p: {b},
+        }
+        dispatch("git tree")
+        self.assertEqual(expected_reduced_parents2, filtered_graph2.parents)
+
+        # Check tags and branch patterns are used appropriately, by swapping patterns
+        # include nodes with branches matching "1" and tags matching "[a-z]"
+        # After:
+        #
+        #              P topic1
+        filtered_graph2a = graph.filter(
+            roots=False, keep_tags=re.compile("[a-z]"), keep_branches=re.compile("1")
+        )
+        expected_reduced_parents2a = {
+            p: set(),
+        }
+        dispatch("git tree")
+        self.assertEqual(expected_reduced_parents2a, filtered_graph2a.parents)
+
+        # drop node topic1, exclude roots
+        # After:
+        #     A 0.0---B 0.1---master
+
+        filtered_graph3 = graph.filter(roots=False, drop_branches=re.compile("topic1"))
+        expected_reduced_parents3 = {
+            a: set(),
+            b: {a},
+            f: {b},
+        }
+        dispatch("git tree")
+        self.assertEqual(expected_reduced_parents3, filtered_graph3.parents)
+
+        # drop node topic1 and tag 0.1, exclude roots
+        # After:
+        #     A 0.0---master
+
+        filtered_graph3a = graph.filter(
+            roots=False, drop_branches=re.compile("topic1"), drop_tags=re.compile("0\\.1")
+        )
+        expected_reduced_parents3a = {
+            a: set(),
+            f: {a},
+        }
+        dispatch("git tree")
+        self.assertEqual(expected_reduced_parents3a, filtered_graph3a.parents)
+
+        # drop node topic1, keep roots
+        # After:
+        #     x -- A 0.0---B 0.1---master
+
+        filtered_graph4 = graph.filter(roots=True, drop_branches=re.compile("topic1"))
+        expected_reduced_parents4 = {
+            x: set(),
+            a: {x},
+            b: {a},
+            f: {b},
+        }
+        dispatch("git tree")
+        self.assertEqual(expected_reduced_parents4, filtered_graph4.parents)
+
+        # drop node topic1, keep tags 0.0 except those containing 1, keep roots
+        # After:
+        #     x -- A 0.0---master
+
+        filtered_graph4 = graph.filter(
+            roots=True,
+            drop_branches=re.compile("topic1"),
+            keep_tags=re.compile("0"),
+            drop_tags=re.compile("1"),
+        )
+        expected_reduced_parents4 = {
+            x: set(),
+            a: {x},
+            f: {a},
+        }
+        dispatch("git tree")
+        self.assertEqual(expected_reduced_parents4, filtered_graph4.parents)
+
+    def test_more_realistic_keep_drop(self):
+        r"""Test a slightly larger DAG
+
+        input:
+                        0.1.1   0.1.2     lab
+                          |       |       |
+            0.0       G---H---I---J---K---L---M maint
+            |        /
+            |       |          epic
+            A---Q---B---C---D---E---F master
+                |   |    \         /
+               qed  0.1    N---O---P topic
+                               |
+                              optic
+        output:
+
+                       0.1.1   0.1.2    lab
+                         |       |       |
+                     ----H-------J-------L
+                    /
+                   |
+               Q---B-----------E epic
+               |   |    \
+              qed  0.1   -----O optic
+
+        """
+        a = empty_commit("A")
+        tag(a, "0.0")
+        q = empty_commit("Q")
+        dispatch("git checkout -b qed %s" % q)
+        dispatch("git checkout master")
+        b = empty_commit("B")
+        tag(b, "0.1")
+        c = empty_commit("C")
+        empty_commit("D")
+        e = empty_commit("E")
+        dispatch("git checkout -b epic %s" % e)
+        dispatch("git checkout -b maint %s" % b)
+        empty_commit("G")
+        h = empty_commit("H")
+        tag(h, "0.1.1")
+        empty_commit("I")
+        j = empty_commit("J")
+        tag(j, "0.1.2")
+        empty_commit("K")
+        node_l = empty_commit("L")
+        dispatch("git checkout -b lab")
+        dispatch("git checkout maint")
+        empty_commit("M")
+        dispatch("git checkout -b topic %s" % c)
+        empty_commit("N")
+        o = empty_commit("O")
+        dispatch("git checkout -b optic")
+        dispatch("git checkout topic")
+        empty_commit("P")
+        dispatch("git checkout master")
+        dispatch("git merge topic")
+        get_head_sha()
+        graph = self.graph
+        dispatch("git tree")
+        filtered_graph = graph.filter(
+            roots=False,
+            keep_tags=re.compile("1"),
+            keep_branches=re.compile("[a-z]"),
+            drop_branches=re.compile("main|aster|topic"),
+        )
+        expected_reduced_parents = {
+            node_l: {j},
+            j: {h},
+            h: {b},
+            b: {q},
+            e: {b},
+            o: {b},
+            q: set(),
+        }
+
+        # same thing, but include bifurcations
+        # output:
+        #
+        #                0.1.1   0.1.2    lab
+        #                  |       |       |
+        #              ----H-------J-------L
+        #             /
+        #            |
+        #        Q---B---C-------E epic
+        #        |   |    \
+        #       qed  0.1   -----O optic
+        self.maxDiff = None
+        self.assertEqual(expected_reduced_parents, filtered_graph.parents)
+
+        filtered_graph2 = graph.filter(
+            roots=False,
+            bifurcations=True,
+            keep_tags=re.compile("[1]"),
+            keep_branches=re.compile("[a-z]"),
+            drop_branches=re.compile("main|aster|topic"),
+        )
+        expected_reduced_parents2 = {
+            node_l: {j},
+            j: {h},
+            h: {b},
+            b: {q},
+            c: {b},
+            e: {c},
+            o: {c},
+            q: set(),
+        }
+        self.assertEqual(expected_reduced_parents2, filtered_graph2.parents)


### PR DESCRIPTION
Fixes #670 

Also fix tests to specify init branch "master", rather than assuming it, since "main" is the default in some places.
